### PR TITLE
Fix Syntax error in 040_2.0.0.sql

### DIFF
--- a/application/modules/setup/sql/040_2.0.0.sql
+++ b/application/modules/setup/sql/040_2.0.0.sql
@@ -8,6 +8,5 @@ ALTER TABLE `ip_users`
 ALTER TABLE `ip_clients`
   ADD COLUMN client_invoicing_contact VARCHAR(50) DEFAULT NULL,
   ADD COLUMN client_einvoice_version VARCHAR(25) DEFAULT NULL,
-  ADD COLUMN client_einvoicing_active TINYINT NOT NULL DEFAULT '0';
+  ADD COLUMN client_einvoicing_active TINYINT NOT NULL DEFAULT '0',
   ADD COLUMN client_company TEXT DEFAULT NULL AFTER `client_name`;
-  


### PR DESCRIPTION
## Description
Fix 
```
Syntax error near 'ADD COLUMN client_company TEXT DEFAULT NULL AFTER `client_name`'
```

## Motivation and Context
Solve a sql problem

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
